### PR TITLE
Force disable dlc flag on autobuilds

### DIFF
--- a/RSDKv3/RetroEngine.cpp
+++ b/RSDKv3/RetroEngine.cpp
@@ -1109,9 +1109,7 @@ bool RetroEngine::LoadGameConfig(const char *filePath)
         LoadXMLStages(NULL, 0);
 #endif
 
-#if !RSDK_AUTOBUILD
-        SetGlobalVariableByName("game.hasPlusDLC", 1);
-#endif
+        SetGlobalVariableByName("game.hasPlusDLC", !RSDK_AUTOBUILD);
 	    
 #if !RETRO_USE_ORIGINAL_CODE
         if (strlen(Engine.startSceneFolder) && strlen(Engine.startSceneID)) {


### PR DESCRIPTION
Prevents Knuckles from being accessible via simply editing the GameConfig to enable the DLC flag.